### PR TITLE
Add .gitignore to exclude environment files and development artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.env
+experiments/tests
+**/.ipynb_checkpoints/
+__pycache__
+*.pyc


### PR DESCRIPTION
This PR introduces a .gitignore file to ensure that unnecessary or sensitive files are not tracked by Git. Specifically, it excludes:

- `.env`: environment-specific configurations and secrets
- `__pycache__/`, `*.pyc`: Python bytecode and cache
- `**/.ipynb_checkpoints/`: Jupyter Notebook checkpoints
- `experiments/`, `tests/`: project-specific folders not meant for versioning

This helps keep the repository clean and reduces the risk of leaking credentials or cluttering the commit history with irrelevant changes.
