### PR TITLE
Add document schema for structuring and storing PDF metadata in the database

### DIFF
--- a/src/models/document.py
+++ b/src/models/document.py
@@ -1,0 +1,10 @@
+from pydantic import BaseModel, Field
+from datetime import datetime
+from typing import Optional
+
+class Document(BaseModel):
+    id: Optional[str] = Field(None, alias="_id")
+    filename: str
+    upload_time: datetime
+    extracted_text: str
+    s3_uri: str


### PR DESCRIPTION
This PR introduces a schema that defines the structure of document-related data to be stored in the database.

Key fields may include:
- Filename and upload timestamp
- Extracted text content
- S3 storage reference (if applicable)
- Metadata such as page count, LLM output, and user identifier

This schema ensures consistency when persisting PDF details and enables easy querying and future expansion of document attributes.
