### PR TITLE
Add FastAPI application entry point in comms/app.py

### DIFF
--- a/src/comms/app.py
+++ b/src/comms/app.py
@@ -1,0 +1,16 @@
+from fastapi import FastAPI
+
+class FastAPIApp:
+    def __init__(self, api_router):
+        self.app = FastAPI(
+            title="PDF Summarizer API",
+            description="API for uploading and extracting text from PDFs",
+            version="1.0.0"
+        )
+        self.app.include_router(api_router.router, tags=["documents"])
+        self._setup_root()
+
+    def _setup_root(self):
+        @self.app.get("/")
+        async def root():
+            return {"message": "PDF Summarizer API is running"}


### PR DESCRIPTION
This PR adds the `comms/app.py` module, which initializes the FastAPI application and serves as the primary communication layer of the project.

Key components:
- FastAPI instance setup
- Modular structure to support clean API route registration

This setup serves as the main entry point for running the backend server and will be extended to include endpoints for PDF upload, text extraction, and LLM interaction.
