### PR TITLE
Add AWS Lambda entry point for FastAPI application

### DIFF
--- a/lambda_function.py
+++ b/lambda_function.py
@@ -1,0 +1,9 @@
+# AWS Lambda Entry-point
+# This file is used to run the FastAPI application on AWS Lambda.
+
+from mangum import Mangum
+from src.orchestrator import Orchestrator
+
+orchestrator = Orchestrator().initialize()
+# The Mangum handler wraps the FastAPI app for AWS Lambda compatibility
+handler = Mangum(orchestrator.fastapi_app.app)


### PR DESCRIPTION
This PR introduces `lambda_function.py` as the AWS Lambda-compatible entry point for deploying the FastAPI application.

Key highlights:
- Utilizes `Mangum` to bridge FastAPI with AWS Lambda via API Gateway
- Enables seamless deployment without modifying core application logic
- Supports serverless architecture for scalable and cost-efficient hosting

This setup ensures that the application is cloud-ready and can be deployed efficiently in AWS Lambda environments.
