### PR TITLE
Add Dockerfile for AWS deployment using official AWS Python base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+# for lambda function
+FROM public.ecr.aws/lambda/python:3.10
+
+# Copy application code
+COPY . ${LAMBDA_TASK_ROOT}
+
+# Install dependencies
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Install Mangum to bridge FastAPI with AWS Lambda
+RUN pip install mangum
+
+CMD ["lambda_function.handler"]


### PR DESCRIPTION
This PR introduces a `Dockerfile` designed for deploying the application to AWS services (e.g., Lambda via container image thorugh Elastic Container Registry).

Highlights:
- Uses the official AWS Python base image for compatibility
- Installs all project dependencies from `requirements.txt`
- Sets up the appropriate working directory and entry point

This Dockerfile streamlines containerized deployments, making the application portable, reproducible, and cloud-ready.
